### PR TITLE
Remove already installed python3-packaging from modules

### DIFF
--- a/pre-pypi-dependencies.json
+++ b/pre-pypi-dependencies.json
@@ -24,21 +24,6 @@
             ]
         },
         {
-            "name": "python3-packaging",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging==24.1\" --no-build-isolation"
-            ],
-            "cleanup": [ "*" ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl",
-                    "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
-                }
-            ]
-        },
-        {
             "name": "python3-setuptools-rust",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
Which fixes this error:
```
Installing collected packages: packaging
  Attempting uninstall: packaging
    Found existing installation: packaging 24.2
    Uninstalling packaging-24.2:
ERROR: Could not install packages due to an OSError. Traceback (most recent call last):
  File "/usr/lib/python3.12/shutil.py", line 847, in move
    os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/usr/lib/python3.12/site-packages/packaging-24.2.dist-info/' -> '/tmp/pip-uninstall-kta12ryz'
```